### PR TITLE
Add management views for colors, sizes, states and email orders

### DIFF
--- a/src/views/gestion/GestionColoresView.vue
+++ b/src/views/gestion/GestionColoresView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import colorService, { Color } from '@/api/colorService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreColor' as const,
+    label: 'Nombre del Color',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<Color[]>([])
+
+const newColorName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await colorService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de colores.', 'danger')
+  }
+})
+
+async function addColor() {
+  if (!newColorName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre del color.', 'info')
+    return
+  }
+  try {
+    const created = await colorService.create({ nombreColor: newColorName.value })
+    rows.value.push(created)
+    newColorName.value = ''
+    openModal('¡Éxito!', 'Color creado correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear el color.', 'danger')
+  }
+}
+
+function handleModify(col: Color) {
+  const newName = prompt('Nuevo nombre del color:', col.nombreColor)
+  if (!newName || !newName.trim()) return
+
+  colorService
+    .update(col.idColor, { idColor: col.idColor, nombreColor: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((c) => c.idColor === col.idColor)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Color actualizado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar el color.', 'danger')
+    })
+}
+
+function handleDelete(col: Color) {
+  const confirmDelete = confirm(`¿Eliminar el color "${col.nombreColor}"?`)
+  if (!confirmDelete) return
+
+  colorService
+    .remove(col.idColor)
+    .then(() => {
+      rows.value = rows.value.filter((c) => c.idColor !== col.idColor)
+      openModal('¡Éxito!', 'Color eliminado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar el color.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Colores</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nuevo Color</h4>
+        <form @submit.prevent="addColor" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre del color"
+              v-model="newColorName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Colores</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>

--- a/src/views/gestion/GestionCorreosPedidosView.vue
+++ b/src/views/gestion/GestionCorreosPedidosView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import correoPedidoService, { CorreoPedido } from '@/api/correoPedidoService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreCorreoPedido' as const,
+    label: 'Nombre del Correo',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<CorreoPedido[]>([])
+
+const newCorreoName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await correoPedidoService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de correos.', 'danger')
+  }
+})
+
+async function addCorreo() {
+  if (!newCorreoName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre del correo.', 'info')
+    return
+  }
+  try {
+    const created = await correoPedidoService.create({ nombreCorreoPedido: newCorreoName.value })
+    rows.value.push(created)
+    newCorreoName.value = ''
+    openModal('¡Éxito!', 'Correo creado correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear el correo.', 'danger')
+  }
+}
+
+function handleModify(cor: CorreoPedido) {
+  const newName = prompt('Nuevo nombre del correo:', cor.nombreCorreoPedido)
+  if (!newName || !newName.trim()) return
+
+  correoPedidoService
+    .update(cor.idCorreoPedido, { idCorreoPedido: cor.idCorreoPedido, nombreCorreoPedido: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((c) => c.idCorreoPedido === cor.idCorreoPedido)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Correo actualizado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar el correo.', 'danger')
+    })
+}
+
+function handleDelete(cor: CorreoPedido) {
+  const confirmDelete = confirm(`¿Eliminar el correo "${cor.nombreCorreoPedido}"?`)
+  if (!confirmDelete) return
+
+  correoPedidoService
+    .remove(cor.idCorreoPedido)
+    .then(() => {
+      rows.value = rows.value.filter((c) => c.idCorreoPedido !== cor.idCorreoPedido)
+      openModal('¡Éxito!', 'Correo eliminado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar el correo.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Correos de Pedido</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nuevo Correo</h4>
+        <form @submit.prevent="addCorreo" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre del correo"
+              v-model="newCorreoName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Correos</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>

--- a/src/views/gestion/GestionEstadosView.vue
+++ b/src/views/gestion/GestionEstadosView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import estadoService, { Estado } from '@/api/estadoService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreEstado' as const,
+    label: 'Nombre del Estado',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<Estado[]>([])
+
+const newEstadoName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await estadoService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de estados.', 'danger')
+  }
+})
+
+async function addEstado() {
+  if (!newEstadoName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre del estado.', 'info')
+    return
+  }
+  try {
+    const created = await estadoService.create({ nombreEstado: newEstadoName.value })
+    rows.value.push(created)
+    newEstadoName.value = ''
+    openModal('¡Éxito!', 'Estado creado correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear el estado.', 'danger')
+  }
+}
+
+function handleModify(est: Estado) {
+  const newName = prompt('Nuevo nombre del estado:', est.nombreEstado)
+  if (!newName || !newName.trim()) return
+
+  estadoService
+    .update(est.idEstado, { idEstado: est.idEstado, nombreEstado: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((e) => e.idEstado === est.idEstado)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Estado actualizado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar el estado.', 'danger')
+    })
+}
+
+function handleDelete(est: Estado) {
+  const confirmDelete = confirm(`¿Eliminar el estado "${est.nombreEstado}"?`)
+  if (!confirmDelete) return
+
+  estadoService
+    .remove(est.idEstado)
+    .then(() => {
+      rows.value = rows.value.filter((e) => e.idEstado !== est.idEstado)
+      openModal('¡Éxito!', 'Estado eliminado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar el estado.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Estados</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nuevo Estado</h4>
+        <form @submit.prevent="addEstado" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre del estado"
+              v-model="newEstadoName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Estados</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>

--- a/src/views/gestion/GestionTallasView.vue
+++ b/src/views/gestion/GestionTallasView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import tallaService, { Talla } from '@/api/tallaService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreTalla' as const,
+    label: 'Nombre de la Talla',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<Talla[]>([])
+
+const newTallaName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await tallaService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de tallas.', 'danger')
+  }
+})
+
+async function addTalla() {
+  if (!newTallaName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre de la talla.', 'info')
+    return
+  }
+  try {
+    const created = await tallaService.create({ nombreTalla: newTallaName.value })
+    rows.value.push(created)
+    newTallaName.value = ''
+    openModal('¡Éxito!', 'Talla creada correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear la talla.', 'danger')
+  }
+}
+
+function handleModify(tal: Talla) {
+  const newName = prompt('Nuevo nombre de la talla:', tal.nombreTalla)
+  if (!newName || !newName.trim()) return
+
+  tallaService
+    .update(tal.idTalla, { idTalla: tal.idTalla, nombreTalla: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((t) => t.idTalla === tal.idTalla)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Talla actualizada.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar la talla.', 'danger')
+    })
+}
+
+function handleDelete(tal: Talla) {
+  const confirmDelete = confirm(`¿Eliminar la talla "${tal.nombreTalla}"?`)
+  if (!confirmDelete) return
+
+  tallaService
+    .remove(tal.idTalla)
+    .then(() => {
+      rows.value = rows.value.filter((t) => t.idTalla !== tal.idTalla)
+      openModal('¡Éxito!', 'Talla eliminada.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar la talla.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Tallas</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nueva Talla</h4>
+        <form @submit.prevent="addTalla" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre de la talla"
+              v-model="newTallaName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Tallas</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>


### PR DESCRIPTION
## Summary
- finish color management view
- finish size management view
- finish status management view
- finish order email management view

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868ba77f79c83298c68292d19733077