### PR TITLE
Add management views for orders

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -59,6 +59,11 @@
                   Agregar Producto
                 </router-link>
               </li>
+              <li>
+                <router-link class="dropdown-item" to="/inventario/pedidos">
+                  Gestionar Pedidos
+                </router-link>
+              </li>
             </ul>
           </li>
           <!-- Nueva sección: Gestión -->

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,7 @@ import HomeView from '@/views/HomeView.vue';
 import AboutView from '@/views/AboutView.vue';
 import InventarioListarView from '@/views/inventario/InventarioListarView.vue';
 import InventarioAgregarView from '@/views/inventario/InventarioAgregarView.vue';
+import GestionPedidosView from '@/views/inventario/GestionPedidosView.vue';
 import CategoryView from '@/views/category/CategoryView.vue'
 import GestionCategoriasView from '@/views/gestion/GestionCategoriasView.vue'
 import GestionSubcategoriasView from '@/views/gestion/GestionSubcategoriasView.vue'
@@ -18,6 +19,7 @@ const routes: Array<RouteRecordRaw> = [
 
   { path: '/inventario/listar', name: 'inventario-listar', component: InventarioListarView, },
   { path: '/inventario/agregar', name: 'inventario-agregar', component: InventarioAgregarView, },
+  { path: '/inventario/pedidos', name: 'inventario-pedidos', component: GestionPedidosView, },
   { path: '/categories', name: 'categories', component: CategoryView, },
   { path: '/gestion/categorias', name: 'gestion-categorias', component: GestionCategoriasView, },
   { path: '/gestion/subcategorias', name: 'gestion-subcategorias', component: GestionSubcategoriasView, },

--- a/src/views/gestion/GestionColoresView.vue
+++ b/src/views/gestion/GestionColoresView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import colorService, { Color } from '@/api/colorService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreColor' as const,
+    label: 'Nombre del Color',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<Color[]>([])
+
+const newColorName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await colorService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de colores.', 'danger')
+  }
+})
+
+async function addColor() {
+  if (!newColorName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre del color.', 'info')
+    return
+  }
+  try {
+    const created = await colorService.create({ nombreColor: newColorName.value })
+    rows.value.push(created)
+    newColorName.value = ''
+    openModal('¡Éxito!', 'Color creado correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear el color.', 'danger')
+  }
+}
+
+function handleModify(col: Color) {
+  const newName = prompt('Nuevo nombre del color:', col.nombreColor)
+  if (!newName || !newName.trim()) return
+
+  colorService
+    .update(col.idColor, { idColor: col.idColor, nombreColor: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((c) => c.idColor === col.idColor)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Color actualizado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar el color.', 'danger')
+    })
+}
+
+function handleDelete(col: Color) {
+  const confirmDelete = confirm(`¿Eliminar el color "${col.nombreColor}"?`)
+  if (!confirmDelete) return
+
+  colorService
+    .remove(col.idColor)
+    .then(() => {
+      rows.value = rows.value.filter((c) => c.idColor !== col.idColor)
+      openModal('¡Éxito!', 'Color eliminado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar el color.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Colores</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nuevo Color</h4>
+        <form @submit.prevent="addColor" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre del color"
+              v-model="newColorName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Colores</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>

--- a/src/views/gestion/GestionCorreosPedidosView.vue
+++ b/src/views/gestion/GestionCorreosPedidosView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import correoPedidoService, { CorreoPedido } from '@/api/correoPedidoService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreCorreoPedido' as const,
+    label: 'Nombre del Correo',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<CorreoPedido[]>([])
+
+const newCorreoName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await correoPedidoService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de correos.', 'danger')
+  }
+})
+
+async function addCorreo() {
+  if (!newCorreoName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre del correo.', 'info')
+    return
+  }
+  try {
+    const created = await correoPedidoService.create({ nombreCorreoPedido: newCorreoName.value })
+    rows.value.push(created)
+    newCorreoName.value = ''
+    openModal('¡Éxito!', 'Correo creado correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear el correo.', 'danger')
+  }
+}
+
+function handleModify(cor: CorreoPedido) {
+  const newName = prompt('Nuevo nombre del correo:', cor.nombreCorreoPedido)
+  if (!newName || !newName.trim()) return
+
+  correoPedidoService
+    .update(cor.idCorreoPedido, { idCorreoPedido: cor.idCorreoPedido, nombreCorreoPedido: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((c) => c.idCorreoPedido === cor.idCorreoPedido)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Correo actualizado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar el correo.', 'danger')
+    })
+}
+
+function handleDelete(cor: CorreoPedido) {
+  const confirmDelete = confirm(`¿Eliminar el correo "${cor.nombreCorreoPedido}"?`)
+  if (!confirmDelete) return
+
+  correoPedidoService
+    .remove(cor.idCorreoPedido)
+    .then(() => {
+      rows.value = rows.value.filter((c) => c.idCorreoPedido !== cor.idCorreoPedido)
+      openModal('¡Éxito!', 'Correo eliminado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar el correo.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Correos de Pedido</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nuevo Correo</h4>
+        <form @submit.prevent="addCorreo" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre del correo"
+              v-model="newCorreoName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Correos</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>

--- a/src/views/gestion/GestionEstadosView.vue
+++ b/src/views/gestion/GestionEstadosView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import estadoService, { Estado } from '@/api/estadoService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreEstado' as const,
+    label: 'Nombre del Estado',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<Estado[]>([])
+
+const newEstadoName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await estadoService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de estados.', 'danger')
+  }
+})
+
+async function addEstado() {
+  if (!newEstadoName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre del estado.', 'info')
+    return
+  }
+  try {
+    const created = await estadoService.create({ nombreEstado: newEstadoName.value })
+    rows.value.push(created)
+    newEstadoName.value = ''
+    openModal('¡Éxito!', 'Estado creado correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear el estado.', 'danger')
+  }
+}
+
+function handleModify(est: Estado) {
+  const newName = prompt('Nuevo nombre del estado:', est.nombreEstado)
+  if (!newName || !newName.trim()) return
+
+  estadoService
+    .update(est.idEstado, { idEstado: est.idEstado, nombreEstado: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((e) => e.idEstado === est.idEstado)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Estado actualizado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar el estado.', 'danger')
+    })
+}
+
+function handleDelete(est: Estado) {
+  const confirmDelete = confirm(`¿Eliminar el estado "${est.nombreEstado}"?`)
+  if (!confirmDelete) return
+
+  estadoService
+    .remove(est.idEstado)
+    .then(() => {
+      rows.value = rows.value.filter((e) => e.idEstado !== est.idEstado)
+      openModal('¡Éxito!', 'Estado eliminado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar el estado.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Estados</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nuevo Estado</h4>
+        <form @submit.prevent="addEstado" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre del estado"
+              v-model="newEstadoName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Estados</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>

--- a/src/views/gestion/GestionTallasView.vue
+++ b/src/views/gestion/GestionTallasView.vue
@@ -1,7 +1,141 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import tallaService, { Talla } from '@/api/tallaService'
 
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  {
+    key: 'nombreTalla' as const,
+    label: 'Nombre de la Talla',
+    type: 'string' as const,
+    sortable: true,
+  },
+]
+
+const rows = ref<Talla[]>([])
+
+const newTallaName = ref('')
+
+onMounted(async () => {
+  try {
+    const data = await tallaService.getAll()
+    rows.value = data
+  } catch (error) {
+    openModal('Error', 'No se pudo obtener la lista de tallas.', 'danger')
+  }
+})
+
+async function addTalla() {
+  if (!newTallaName.value.trim()) {
+    openModal('Información Incompleta', 'Ingrese el nombre de la talla.', 'info')
+    return
+  }
+  try {
+    const created = await tallaService.create({ nombreTalla: newTallaName.value })
+    rows.value.push(created)
+    newTallaName.value = ''
+    openModal('¡Éxito!', 'Talla creada correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear la talla.', 'danger')
+  }
+}
+
+function handleModify(tal: Talla) {
+  const newName = prompt('Nuevo nombre de la talla:', tal.nombreTalla)
+  if (!newName || !newName.trim()) return
+
+  tallaService
+    .update(tal.idTalla, { idTalla: tal.idTalla, nombreTalla: newName })
+    .then((updated) => {
+      const idx = rows.value.findIndex((t) => t.idTalla === tal.idTalla)
+      if (idx !== -1) rows.value[idx] = updated
+      openModal('¡Éxito!', 'Talla actualizada.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar la talla.', 'danger')
+    })
+}
+
+function handleDelete(tal: Talla) {
+  const confirmDelete = confirm(`¿Eliminar la talla "${tal.nombreTalla}"?`)
+  if (!confirmDelete) return
+
+  tallaService
+    .remove(tal.idTalla)
+    .then(() => {
+      rows.value = rows.value.filter((t) => t.idTalla !== tal.idTalla)
+      openModal('¡Éxito!', 'Talla eliminada.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar la talla.', 'danger')
+    })
+}
 </script>
 
 <template>
-    
+  <div class="container mt-4">
+    <h2>Gestión de Tallas</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nueva Talla</h4>
+        <form @submit.prevent="addTalla" class="row g-3">
+          <div class="col-auto">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Nombre de la talla"
+              v-model="newTallaName"
+              required
+            />
+          </div>
+          <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Tallas</h4>
+        <CategoryTable
+          :columns="columns"
+          :rows="rows"
+          enableActions
+          @modify="handleModify"
+          @delete="handleDelete"
+        />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert
+      :show="showModal"
+      :title="modalTitle"
+      :message="modalMessage"
+      :type="modalType"
+      @close="handleClose"
+    />
+  </div>
 </template>

--- a/src/views/inventario/GestionPedidosView.vue
+++ b/src/views/inventario/GestionPedidosView.vue
@@ -1,0 +1,214 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import pedidoService, { type Pedido } from '@/api/pedidoService'
+import correoPedidoService, { type CorreoPedido } from '@/api/correoPedidoService'
+
+import CategoryTable from '@/components/CategoryTable.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
+import ModalAlert from '@/components/ModalAlert.vue'
+
+interface PedidoRow extends Pedido {
+  correoNombre: string
+}
+
+const showModal = ref(false)
+const modalTitle = ref('')
+const modalMessage = ref('')
+const modalType = ref<'success' | 'danger' | 'warning' | 'info'>('info')
+
+function openModal(
+  title: string,
+  message: string,
+  type: 'success' | 'danger' | 'warning' | 'info',
+) {
+  modalTitle.value = title
+  modalMessage.value = message
+  modalType.value = type
+  showModal.value = true
+}
+
+function handleClose() {
+  showModal.value = false
+}
+
+const columns = [
+  { key: 'numeroPedido' as const, label: 'Número', type: 'string' as const, sortable: true },
+  { key: 'fechaPedido' as const, label: 'Fecha Pedido', type: 'date' as const, sortable: true },
+  { key: 'fechaLlegada' as const, label: 'Fecha Llegada', type: 'date' as const, sortable: true },
+  { key: 'totalPedido' as const, label: 'Total', type: 'number' as const, sortable: true },
+  { key: 'nota' as const, label: 'Nota', type: 'string' as const },
+  { key: 'correoNombre' as const, label: 'Correo', type: 'string' as const, sortable: true },
+]
+
+const rows = ref<PedidoRow[]>([])
+const correos = ref<CorreoPedido[]>([])
+
+const newPedido = ref({
+  numeroPedido: '',
+  fechaPedido: '',
+  fechaLlegada: '',
+  totalPedido: 0,
+  nota: '',
+  idCorreoPedido: 0,
+})
+
+onMounted(async () => {
+  try {
+    const [pedidosData, correosData] = await Promise.all([
+      pedidoService.getAll(),
+      correoPedidoService.getAll(),
+    ])
+    correos.value = correosData
+    rows.value = pedidosData.map((p) => ({
+      ...p,
+      correoNombre:
+        correosData.find((c) => c.idCorreoPedido === p.idCorreoPedido)?.nombreCorreoPedido || '',
+    }))
+  } catch (error) {
+    openModal('Error', 'No se pudieron obtener los datos.', 'danger')
+  }
+})
+
+async function addPedido() {
+  if (!newPedido.value.numeroPedido.trim() || !newPedido.value.fechaPedido) {
+    openModal('Información Incompleta', 'Complete los datos obligatorios.', 'info')
+    return
+  }
+
+  const pedidoPayload: Omit<Pedido, 'idPedido'> = {
+    numeroPedido: newPedido.value.numeroPedido,
+    fechaPedido: new Date(newPedido.value.fechaPedido),
+    fechaLlegada: newPedido.value.fechaLlegada
+      ? new Date(newPedido.value.fechaLlegada)
+      : undefined,
+    totalPedido: newPedido.value.totalPedido || undefined,
+    nota: newPedido.value.nota || undefined,
+    idCorreoPedido: newPedido.value.idCorreoPedido,
+  }
+
+  try {
+    const created = await pedidoService.create({ pedido: pedidoPayload, productos: [] })
+    rows.value.push({
+      ...created,
+      correoNombre:
+        correos.value.find((c) => c.idCorreoPedido === created.idCorreoPedido)?.nombreCorreoPedido || '',
+    })
+    newPedido.value = {
+      numeroPedido: '',
+      fechaPedido: '',
+      fechaLlegada: '',
+      totalPedido: 0,
+      nota: '',
+      idCorreoPedido: 0,
+    }
+    openModal('¡Éxito!', 'Pedido creado correctamente.', 'success')
+  } catch (error) {
+    openModal('Error', 'No se pudo crear el pedido.', 'danger')
+  }
+}
+
+function handleModify(ped: PedidoRow) {
+  const numero = prompt('Número del pedido:', ped.numeroPedido) || ped.numeroPedido
+  const fecha = prompt(
+    'Fecha del pedido (YYYY-MM-DD):',
+    new Date(ped.fechaPedido).toISOString().slice(0, 10),
+  ) || new Date(ped.fechaPedido).toISOString().slice(0, 10)
+  const llegada = prompt(
+    'Fecha llegada (YYYY-MM-DD):',
+    ped.fechaLlegada ? new Date(ped.fechaLlegada).toISOString().slice(0, 10) : '',
+  )
+  const totalStr = prompt('Total del pedido:', ped.totalPedido?.toString() || '0')
+  const nota = prompt('Nota:', ped.nota ?? '') || ''
+  const correoIdStr = prompt('ID del correo pedido:', ped.idCorreoPedido.toString())
+
+  const payload: Pedido = {
+    idPedido: ped.idPedido,
+    numeroPedido: numero,
+    fechaPedido: new Date(fecha),
+    fechaLlegada: llegada ? new Date(llegada) : undefined,
+    totalPedido: totalStr ? parseFloat(totalStr) : undefined,
+    nota,
+    idCorreoPedido: correoIdStr ? parseInt(correoIdStr) : ped.idCorreoPedido,
+  }
+
+  pedidoService
+    .update(ped.idPedido, { pedido: payload, productos: [] })
+    .then((updated) => {
+      const idx = rows.value.findIndex((p) => p.idPedido === ped.idPedido)
+      if (idx !== -1) {
+        rows.value[idx] = {
+          ...updated,
+          correoNombre:
+            correos.value.find((c) => c.idCorreoPedido === updated.idCorreoPedido)?.nombreCorreoPedido || '',
+        }
+      }
+      openModal('¡Éxito!', 'Pedido actualizado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo actualizar el pedido.', 'danger')
+    })
+}
+
+function handleDelete(ped: PedidoRow) {
+  const confirmDelete = confirm(`¿Eliminar el pedido "${ped.numeroPedido}"?`)
+  if (!confirmDelete) return
+
+  pedidoService
+    .remove(ped.idPedido)
+    .then(() => {
+      rows.value = rows.value.filter((p) => p.idPedido !== ped.idPedido)
+      openModal('¡Éxito!', 'Pedido eliminado.', 'success')
+    })
+    .catch(() => {
+      openModal('Error', 'No se pudo eliminar el pedido.', 'danger')
+    })
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <h2>Gestión de Pedidos</h2>
+
+    <TransparentCard>
+      <div class="my-3">
+        <h4>Agregar Nuevo Pedido</h4>
+        <form @submit.prevent="addPedido" class="row g-3">
+          <div class="col-md-4">
+            <input type="text" class="form-control" placeholder="Número" v-model="newPedido.numeroPedido" required />
+          </div>
+          <div class="col-md-4">
+            <input type="date" class="form-control" v-model="newPedido.fechaPedido" required />
+          </div>
+          <div class="col-md-4">
+            <input type="date" class="form-control" v-model="newPedido.fechaLlegada" />
+          </div>
+          <div class="col-md-4">
+            <input type="number" step="0.01" class="form-control" placeholder="Total" v-model.number="newPedido.totalPedido" />
+          </div>
+          <div class="col-md-4">
+            <input type="text" class="form-control" placeholder="Nota" v-model="newPedido.nota" />
+          </div>
+          <div class="col-md-4">
+            <select class="form-select" v-model.number="newPedido.idCorreoPedido" required>
+              <option value="0" disabled>Seleccione un correo</option>
+              <option v-for="c in correos" :key="c.idCorreoPedido" :value="c.idCorreoPedido">{{ c.nombreCorreoPedido }}</option>
+            </select>
+          </div>
+          <div class="col-12">
+            <button type="submit" class="btn btn-primary">Agregar</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="my-3">
+        <h4>Listado de Pedidos</h4>
+        <CategoryTable :columns="columns" :rows="rows" enableActions @modify="handleModify" @delete="handleDelete" />
+      </div>
+    </TransparentCard>
+
+    <ModalAlert :show="showModal" :title="modalTitle" :message="modalMessage" :type="modalType" @close="handleClose" />
+  </div>
+</template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- add GestionPedidosView to handle CRUD of pedidos in Inventario
- wire up route and navbar link for new order management module

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868ba77f79c83298c68292d19733077