### PR TITLE
Add simple reportes module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "pinia": "^2.3.0",
         "vite-project": "file:",
         "vue": "^3.5.11",
-        "vue-router": "^4.5.0"
+        "vue-router": "^4.5.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/node": "^22.16.0",
@@ -1431,6 +1432,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1562,6 +1572,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1577,6 +1600,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -1617,6 +1649,18 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2147,6 +2191,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -3033,6 +3086,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3449,6 +3514,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3465,6 +3548,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "pinia": "^2.3.0",
     "vite-project": "file:",
     "vue": "^3.5.11",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/node": "^22.16.0",

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -95,6 +95,9 @@
               </li>
             </ul>
           </li>
+          <li class="nav-item">
+            <router-link class="nav-link" to="/reportes">Reportes</router-link>
+          </li>
         </ul>
       </div>
     </div>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,6 +12,7 @@ import GestionColoresView from '@/views/gestion/GestionColoresView.vue'
 import GestionTallasView from '@/views/gestion/GestionTallasView.vue'
 import GestionEstadosView from '@/views/gestion/GestionEstadosView.vue'
 import GestionCorreosPedidosView from '@/views/gestion/GestionCorreosPedidosView.vue'
+import ReportesView from '@/views/reportes/ReportesView.vue'
 
 const routes: Array<RouteRecordRaw> = [    
   { path: '/', name: 'home', component: HomeView, },
@@ -28,6 +29,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/gestion/tallas', name: 'gestion-tallas', component: GestionTallasView },
   { path: '/gestion/estados', name: 'gestion-estados', component: GestionEstadosView },
   { path: '/gestion/correospedidos', name: 'gestion-correospedidos', component: GestionCorreosPedidosView },
+  { path: '/reportes', name: 'reportes', component: ReportesView },
 ];
 
 const router = createRouter({

--- a/src/views/reportes/ReportesView.vue
+++ b/src/views/reportes/ReportesView.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import * as XLSX from 'xlsx'
+import productoService, { type Producto } from '@/api/productoService'
+import TransparentCard from '@/components/TransparentCard.vue'
+import CategoryTable from '@/components/CategoryTable.vue'
+
+interface ColumnDef {
+  key: string
+  label: string
+  type: 'string' | 'number' | 'date'
+  sortable?: boolean
+}
+
+const inventario = ref<Producto[]>([])
+
+const productColumns: ColumnDef[] = [
+  { key: 'sku', label: 'SKU', type: 'string', sortable: true },
+  { key: 'nombreProducto', label: 'Nombre', type: 'string', sortable: true },
+  { key: 'precioCompra', label: 'Precio Compra', type: 'number' },
+  { key: 'precioVenta', label: 'Precio Venta', type: 'number' },
+  { key: 'idEstado', label: 'Estado', type: 'number' },
+]
+
+onMounted(async () => {
+  try {
+    inventario.value = await productoService.getAll()
+  } catch (error) {
+    console.error(error)
+    alert('Error al cargar inventario')
+  }
+})
+
+function exportInventario() {
+  const data = inventario.value.map(p => ({
+    SKU: p.sku,
+    Nombre: p.nombreProducto,
+    PrecioCompra: p.precioCompra,
+    PrecioVenta: p.precioVenta,
+    Estado: p.idEstado,
+  }))
+  const ws = XLSX.utils.json_to_sheet(data)
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, 'Inventario')
+  XLSX.writeFile(wb, 'inventario.xlsx')
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <h1 class="mb-4">Reportes</h1>
+    <TransparentCard>
+      <h3>Inventario</h3>
+      <button class="btn btn-primary mb-3" @click="exportInventario">
+        Exportar a Excel
+      </button>
+      <CategoryTable :columns="productColumns" :rows="inventario" />
+    </TransparentCard>
+  </div>
+</template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Resumen
- agregar dependencia `xlsx` para exportar datos
- crear vista `ReportesView` con tabla de inventario y descarga en Excel
- registrar la nueva ruta y enlace en el `Navbar`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b27875d1c8329a88b239fbc9817ab