### PR TITLE
Implement separate inventory and sales reports

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -95,8 +95,25 @@
               </li>
             </ul>
           </li>
-          <li class="nav-item">
-            <router-link class="nav-link" to="/reportes">Reportes</router-link>
+          <li class="nav-item dropdown">
+            <a
+              class="nav-link dropdown-toggle"
+              href="#"
+              id="navbarReportes"
+              role="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              Reportes
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="navbarReportes">
+              <li>
+                <router-link class="dropdown-item" to="/reportes/inventario">Inventario</router-link>
+              </li>
+              <li>
+                <router-link class="dropdown-item" to="/reportes/ventas">Ventas</router-link>
+              </li>
+            </ul>
           </li>
         </ul>
       </div>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,7 +12,8 @@ import GestionColoresView from '@/views/gestion/GestionColoresView.vue'
 import GestionTallasView from '@/views/gestion/GestionTallasView.vue'
 import GestionEstadosView from '@/views/gestion/GestionEstadosView.vue'
 import GestionCorreosPedidosView from '@/views/gestion/GestionCorreosPedidosView.vue'
-import ReportesView from '@/views/reportes/ReportesView.vue'
+import ReporteInventarioView from '@/views/reportes/ReporteInventarioView.vue'
+import ReporteVentasView from '@/views/reportes/ReporteVentasView.vue'
 
 const routes: Array<RouteRecordRaw> = [    
   { path: '/', name: 'home', component: HomeView, },
@@ -29,7 +30,8 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/gestion/tallas', name: 'gestion-tallas', component: GestionTallasView },
   { path: '/gestion/estados', name: 'gestion-estados', component: GestionEstadosView },
   { path: '/gestion/correospedidos', name: 'gestion-correospedidos', component: GestionCorreosPedidosView },
-  { path: '/reportes', name: 'reportes', component: ReportesView },
+  { path: '/reportes/inventario', name: 'reporte-inventario', component: ReporteInventarioView },
+  { path: '/reportes/ventas', name: 'reporte-ventas', component: ReporteVentasView },
 ];
 
 const router = createRouter({

--- a/src/views/reportes/ReporteVentasView.vue
+++ b/src/views/reportes/ReporteVentasView.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import * as XLSX from 'xlsx'
+import productoService, { type Producto } from '@/api/productoService'
+import TransparentCard from '@/components/TransparentCard.vue'
+import CategoryTable from '@/components/CategoryTable.vue'
+
+interface ColumnDef {
+  key: string
+  label: string
+  type: 'string' | 'number' | 'date'
+  sortable?: boolean
+}
+
+function formatDate(d?: string | Date): string {
+  if (!d) return ''
+  const dateObj = typeof d === 'string' ? new Date(d) : d
+  if (isNaN(dateObj.getTime())) return ''
+  const dd = String(dateObj.getDate()).padStart(2, '0')
+  const mm = String(dateObj.getMonth() + 1).padStart(2, '0')
+  const yyyy = dateObj.getFullYear()
+  return `${dd}-${mm}-${yyyy}`
+}
+
+function formatCurrency(n?: number): string {
+  if (n == null) return ''
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(n)
+}
+
+const inventario = ref<Producto[]>([])
+
+interface VentaRow {
+  sku?: string
+  nombre: string
+  fechaVenta: string
+  precioCompra: string
+  precioVenta: string
+  ganancia: string
+}
+
+const fechaInicio = ref('')
+const fechaFin = ref('')
+
+const ventasRows = computed<VentaRow[]>(() => {
+  return inventario.value
+    .filter(p => {
+      if (!p.fechaActualizacion) return false
+      const f = new Date(p.fechaActualizacion)
+      if (fechaInicio.value && f < new Date(fechaInicio.value)) return false
+      if (fechaFin.value && f > new Date(fechaFin.value)) return false
+      return true
+    })
+    .map(p => ({
+      sku: p.sku,
+      nombre: p.nombreProducto,
+      fechaVenta: formatDate(p.fechaActualizacion),
+      precioCompra: formatCurrency(p.precioCompra),
+      precioVenta: formatCurrency(p.precioVenta),
+      ganancia: formatCurrency(p.precioVenta - p.precioCompra),
+    }))
+})
+
+const ventaColumns: ColumnDef[] = [
+  { key: 'sku', label: 'SKU', type: 'string', sortable: true },
+  { key: 'nombre', label: 'Nombre', type: 'string', sortable: true },
+  { key: 'fechaVenta', label: 'Fecha Venta', type: 'date', sortable: true },
+  { key: 'precioCompra', label: 'Precio Compra', type: 'string' },
+  { key: 'precioVenta', label: 'Precio Venta', type: 'string' },
+  { key: 'ganancia', label: 'Ganancia', type: 'string' },
+]
+
+onMounted(async () => {
+  try {
+    inventario.value = await productoService.getAll()
+  } catch (error) {
+    console.error(error)
+    alert('Error al cargar ventas')
+  }
+})
+
+function exportVentas() {
+  const data = ventasRows.value.map(v => ({
+    SKU: v.sku,
+    Nombre: v.nombre,
+    FechaVenta: v.fechaVenta,
+    PrecioCompra: v.precioCompra,
+    PrecioVenta: v.precioVenta,
+    Ganancia: v.ganancia,
+  }))
+  const ws = XLSX.utils.json_to_sheet(data)
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, 'Ventas')
+  XLSX.writeFile(wb, 'ventas.xlsx')
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <h1 class="mb-4">Reporte Ventas</h1>
+    <TransparentCard>
+      <div class="row g-3 mb-3">
+        <div class="col-md-4">
+          <label class="form-label">Fecha inicio</label>
+          <input type="date" class="form-control" v-model="fechaInicio" />
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Fecha fin</label>
+          <input type="date" class="form-control" v-model="fechaFin" />
+        </div>
+        <div class="col-md-4 d-flex align-items-end">
+          <button class="btn btn-primary me-2" @click="exportVentas">Descargar Excel</button>
+        </div>
+      </div>
+      <CategoryTable :columns="ventaColumns" :rows="ventasRows" />
+    </TransparentCard>
+  </div>
+</template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- add inventory and sales report pages
- update navbar with report dropdown
- route new pages in router
- remove old reportes view

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b4208d8cc832988518e4910e10374