### PR TITLE
Add unified Gestión page

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -67,33 +67,8 @@
             </ul>
           </li>
           <!-- Nueva sección: Gestión -->
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarGestion" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Gestión
-            </a>
-            <ul class="dropdown-menu" aria-labelledby="navbarGestion">
-              <li>
-                <router-link class="dropdown-item" to="/gestion/categorias">Categorías</router-link>
-              </li>
-              <li>
-                <router-link class="dropdown-item" to="/gestion/subcategorias">Sub-Categorías</router-link>
-              </li>
-              <li>
-                <router-link class="dropdown-item" to="/gestion/generos">Géneros</router-link>
-              </li>
-              <li>
-                <router-link class="dropdown-item" to="/gestion/colores">Colores</router-link>
-              </li>
-              <li>
-                <router-link class="dropdown-item" to="/gestion/tallas">Tallas</router-link>
-              </li>
-              <li>
-                <router-link class="dropdown-item" to="/gestion/estados">Estados</router-link>
-              </li>
-              <li>
-                <router-link class="dropdown-item" to="/gestion/correospedidos">Correos Pedidos</router-link>
-              </li>
-            </ul>
+          <li class="nav-item">
+            <router-link class="nav-link" to="/gestion">Gestión</router-link>
           </li>
           <li class="nav-item dropdown">
             <a

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,6 +12,7 @@ import GestionColoresView from '@/views/gestion/GestionColoresView.vue'
 import GestionTallasView from '@/views/gestion/GestionTallasView.vue'
 import GestionEstadosView from '@/views/gestion/GestionEstadosView.vue'
 import GestionCorreosPedidosView from '@/views/gestion/GestionCorreosPedidosView.vue'
+import GestionView from '@/views/GestionView.vue'
 import ReporteInventarioView from '@/views/reportes/ReporteInventarioView.vue'
 import ReporteVentasView from '@/views/reportes/ReporteVentasView.vue'
 
@@ -23,6 +24,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/inventario/agregar', name: 'inventario-agregar', component: InventarioAgregarView, },
   { path: '/inventario/pedidos', name: 'inventario-pedidos', component: GestionPedidosView, },
   { path: '/categories', name: 'categories', component: CategoryView, },
+  { path: '/gestion', name: 'gestion', component: GestionView },
   { path: '/gestion/categorias', name: 'gestion-categorias', component: GestionCategoriasView, },
   { path: '/gestion/subcategorias', name: 'gestion-subcategorias', component: GestionSubcategoriasView, },
   { path: '/gestion/generos', name: 'gestion-generos', component: GestionGenerosView },

--- a/src/views/GestionView.vue
+++ b/src/views/GestionView.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import GestionCategoriasView from './gestion/GestionCategoriasView.vue'
+import GestionSubcategoriasView from './gestion/GestionSubcategoriasView.vue'
+import GestionGenerosView from './gestion/GestionGenerosView.vue'
+import GestionColoresView from './gestion/GestionColoresView.vue'
+import GestionTallasView from './gestion/GestionTallasView.vue'
+import GestionEstadosView from './gestion/GestionEstadosView.vue'
+import GestionCorreosPedidosView from './gestion/GestionCorreosPedidosView.vue'
+
+interface Module {
+  key: string
+  label: string
+  component: any
+}
+
+const modules: Module[] = [
+  { key: 'categorias', label: 'Categorías', component: GestionCategoriasView },
+  { key: 'subcategorias', label: 'Subcategorías', component: GestionSubcategoriasView },
+  { key: 'generos', label: 'Géneros', component: GestionGenerosView },
+  { key: 'colores', label: 'Colores', component: GestionColoresView },
+  { key: 'tallas', label: 'Tallas', component: GestionTallasView },
+  { key: 'estados', label: 'Estados', component: GestionEstadosView },
+  { key: 'correos', label: 'Correos Pedidos', component: GestionCorreosPedidosView },
+]
+
+const selected = ref<Module | null>(null)
+
+function selectModule(mod: Module) {
+  selected.value = mod
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <h2>Gestión</h2>
+
+    <div class="mb-3">
+      <button
+        v-for="mod in modules"
+        :key="mod.key"
+        class="btn btn-primary me-2 mb-2"
+        @click="selectModule(mod)"
+      >
+        {{ mod.label }}
+      </button>
+    </div>
+
+    <component v-if="selected" :is="selected.component" />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add `GestionView.vue` to consolidate management modules on one page
- update router with new `/gestion` route
- simplify navbar with a single Gestión link

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755873ae048329bdb6f5fc88ff5c61