### PR TITLE
Show default placeholder on Gestion page

### DIFF
--- a/src/views/GestionView.vue
+++ b/src/views/GestionView.vue
@@ -7,6 +7,7 @@ import GestionColoresView from './gestion/GestionColoresView.vue'
 import GestionTallasView from './gestion/GestionTallasView.vue'
 import GestionEstadosView from './gestion/GestionEstadosView.vue'
 import GestionCorreosPedidosView from './gestion/GestionCorreosPedidosView.vue'
+import TransparentCard from '@/components/TransparentCard.vue'
 
 interface Module {
   key: string
@@ -47,5 +48,9 @@ function selectModule(mod: Module) {
     </div>
 
     <component v-if="selected" :is="selected.component" />
+    <TransparentCard v-else class="text-center py-5">
+      <h3 class="mb-3">Control y Gestión de Inventario</h3>
+      <p>Seleccione un módulo para actualizar</p>
+    </TransparentCard>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show inventory management placeholder message when no module is selected

## Testing
- `npm run build` *(fails: vue-tsc not found due to missing dependencies)*
- `npm install` *(fails: 403 Forbidden for xlsx-latest.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68755b1bc4808329b3eaeb3041d756af